### PR TITLE
feat: accept and pass back tracking fields in `ExecutorResult`

### DIFF
--- a/unicon_runner/executor/variants/base.py
+++ b/unicon_runner/executor/variants/base.py
@@ -2,19 +2,16 @@ import os
 import shutil
 from abc import ABC, abstractmethod
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from unicon_runner.schemas import Request, Status
 
 
 class ExecutorResult(BaseModel):
+    model_config = ConfigDict(extra="allow")
     stdout: str
     stderr: str
     status: Status
-
-
-class ExecutorResultWithId(ExecutorResult):
-    id: int
 
 
 class Executor(ABC):

--- a/unicon_runner/executor/variants/base.py
+++ b/unicon_runner/executor/variants/base.py
@@ -39,7 +39,6 @@ class Executor(ABC):
 
     def clean_up_folder(self, folder_path: str):
         """Cleans up the temporary folder"""
-        # time.sleep(5)
         shutil.rmtree(folder_path)
 
     @abstractmethod

--- a/unicon_runner/executor/variants/base.py
+++ b/unicon_runner/executor/variants/base.py
@@ -13,6 +13,10 @@ class ExecutorResult(BaseModel):
     status: Status
 
 
+class ExecutorResultWithId(ExecutorResult):
+    id: int
+
+
 class Executor(ABC):
     on_slurm = False
 

--- a/unicon_runner/runner/task/programming.py
+++ b/unicon_runner/runner/task/programming.py
@@ -4,7 +4,7 @@ from typing import Any, Self
 
 from pydantic import BaseModel, model_validator
 
-from unicon_runner.executor.variants.base import Executor
+from unicon_runner.executor.variants.base import Executor, ExecutorResult
 from unicon_runner.schemas import (
     File,
     ProgrammingEnvironment,
@@ -32,8 +32,8 @@ class Programs(BaseModel):
     environment: ProgrammingEnvironment
     programs: list[Program]
 
-    async def run(self, executor: Executor) -> TaskEvalResult[list[Any]]:
-        results_with_index: dict[int, Any] = {}
+    async def run(self, executor: Executor) -> TaskEvalResult[list[ExecutorResult]]:
+        results_with_index: dict[int, ExecutorResult] = {}
         async with asyncio.TaskGroup() as tg:
             for index, request in enumerate(self.programs):
                 tg.create_task(self.run_program(executor, request, index, results_with_index))
@@ -51,7 +51,7 @@ class Programs(BaseModel):
         executor: Executor,
         program: Program,
         index: int,
-        results: dict,
+        results: dict[int, ExecutorResult],
     ):
         request = Request(**program.model_dump(), environment=self.environment)
         results[index] = await executor.run_request(request, str(uuid.uuid4()))

--- a/unicon_runner/runner/task/programming.py
+++ b/unicon_runner/runner/task/programming.py
@@ -1,10 +1,10 @@
 import asyncio
 import uuid
-from typing import Any, Self
+from typing import Self
 
 from pydantic import BaseModel, model_validator
 
-from unicon_runner.executor.variants.base import Executor, ExecutorResult
+from unicon_runner.executor.variants.base import Executor, ExecutorResult, ExecutorResultWithId
 from unicon_runner.schemas import (
     File,
     ProgrammingEnvironment,
@@ -17,6 +17,8 @@ from unicon_runner.schemas import (
 class Program(BaseModel):
     """Equivalent to RunnerPackage in unicon_backend"""
 
+    id: int
+    """used for testcase_id in unicon_backend, but the runner doesnt need to know that, just needs to parrot it back"""
     entrypoint: str
     files: list[File]
 
@@ -32,14 +34,14 @@ class Programs(BaseModel):
     environment: ProgrammingEnvironment
     programs: list[Program]
 
-    async def run(self, executor: Executor) -> TaskEvalResult[list[ExecutorResult]]:
-        results_with_index: dict[int, ExecutorResult] = {}
+    async def run(self, executor: Executor) -> TaskEvalResult[list[ExecutorResultWithId]]:
+        results_with_index: dict[int, ExecutorResultWithId] = {}
         async with asyncio.TaskGroup() as tg:
             for index, request in enumerate(self.programs):
                 tg.create_task(self.run_program(executor, request, index, results_with_index))
 
         results = [results_with_index[i] for i in range(len(results_with_index))]
-
+        print(results)
         return TaskEvalResult(
             submission_id=self.submission_id,
             status=TaskEvalStatus.SUCCESS,
@@ -51,7 +53,10 @@ class Programs(BaseModel):
         executor: Executor,
         program: Program,
         index: int,
-        results: dict[int, ExecutorResult],
+        results: dict[int, ExecutorResultWithId],
     ):
         request = Request(**program.model_dump(), environment=self.environment)
-        results[index] = await executor.run_request(request, str(uuid.uuid4()))
+        result = await executor.run_request(request, str(uuid.uuid4()))
+        results[index] = ExecutorResultWithId.model_validate(
+            {"id": program.id, **result.model_dump()}
+        )

--- a/unicon_runner/runner/task/programming.py
+++ b/unicon_runner/runner/task/programming.py
@@ -4,7 +4,7 @@ from typing import Self
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
-from unicon_runner.executor.variants.base import Executor, ExecutorResult, ExecutorResult
+from unicon_runner.executor.variants.base import Executor, ExecutorResult
 from unicon_runner.schemas import (
     File,
     ProgrammingEnvironment,
@@ -19,7 +19,6 @@ class Program(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
-    """used for testcase_id in unicon_backend, but the runner doesnt need to know that, just needs to parrot it back"""
     entrypoint: str
     files: list[File]
 

--- a/unicon_runner/runner/task/programming.py
+++ b/unicon_runner/runner/task/programming.py
@@ -2,9 +2,9 @@ import asyncio
 import uuid
 from typing import Self
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, ConfigDict, model_validator
 
-from unicon_runner.executor.variants.base import Executor, ExecutorResult, ExecutorResultWithId
+from unicon_runner.executor.variants.base import Executor, ExecutorResult, ExecutorResult
 from unicon_runner.schemas import (
     File,
     ProgrammingEnvironment,
@@ -17,7 +17,8 @@ from unicon_runner.schemas import (
 class Program(BaseModel):
     """Equivalent to RunnerPackage in unicon_backend"""
 
-    id: int
+    model_config = ConfigDict(extra="allow")
+
     """used for testcase_id in unicon_backend, but the runner doesnt need to know that, just needs to parrot it back"""
     entrypoint: str
     files: list[File]
@@ -34,14 +35,14 @@ class Programs(BaseModel):
     environment: ProgrammingEnvironment
     programs: list[Program]
 
-    async def run(self, executor: Executor) -> TaskEvalResult[list[ExecutorResultWithId]]:
-        results_with_index: dict[int, ExecutorResultWithId] = {}
+    async def run(self, executor: Executor) -> TaskEvalResult[list[ExecutorResult]]:
+        results_with_index: dict[int, ExecutorResult] = {}
         async with asyncio.TaskGroup() as tg:
             for index, request in enumerate(self.programs):
                 tg.create_task(self.run_program(executor, request, index, results_with_index))
 
         results = [results_with_index[i] for i in range(len(results_with_index))]
-        print(results)
+
         return TaskEvalResult(
             submission_id=self.submission_id,
             status=TaskEvalStatus.SUCCESS,
@@ -53,10 +54,10 @@ class Programs(BaseModel):
         executor: Executor,
         program: Program,
         index: int,
-        results: dict[int, ExecutorResultWithId],
+        results: dict[int, ExecutorResult],
     ):
         request = Request(**program.model_dump(), environment=self.environment)
         result = await executor.run_request(request, str(uuid.uuid4()))
-        results[index] = ExecutorResultWithId.model_validate(
-            {"id": program.id, **result.model_dump()}
+        results[index] = ExecutorResult.model_validate(
+            {**(program.model_extra or {}), **result.model_dump()}
         )


### PR DESCRIPTION
- used for identifying testcases

needed by https://github.com/uniconhq/unicon-backend/pull/49