### PR TITLE
feat: add runtime param to execute program via `slurm`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,35 @@
 # Unicon 🦄 Runner
 
-Starting the runner and connecting to the work/task queue:
+Starting a long-running process that listens to the task queue:
 
 ```bash
-RABBITMQ_URL="<ampq-url>" EXECUTOR_TYPE="[podman | sandbox | unsafe]" uv run unicon-runner/app.py
+uv run unicon_runner/app.py \
+    start [unsafe | sandbox | podman] <root-working-dir>
 ```
+> [!NOTE]
+`RABBITMQ_URL` needs to be set either in the `.env` file or as an environment variable.
+
+> `<root-working-dir>` is the root directory where working directories for each program execution will be created. This directory should be writable by the user running the runner.
+
+Test the runner with a sample program:
+
+```bash
+uv run unicon_runner/app.py \
+    test [unsafe | sandbox | podman] <root-working-dir> \
+    <job-json-file> \
+    [--slurm] \
+    [--slurm_opt <slurm-option>]
+
+# Example of running a job with the sandbox executor that 
+# requires runtime dependencies on a Slurm cluster and (also a GPU just for fun)
+uv run unicon_runner/app.py \
+    test sandbox ./temp \
+    examples/runtime_deps.json \
+    --slurm \
+    --slurm_opt "--gpus=1"
+```
+
+> Example job files can be found in the `/examples` directory.
 
 ## Executors
 

--- a/examples/hello_world.json
+++ b/examples/hello_world.json
@@ -1,0 +1,19 @@
+{
+    "programs": [
+        {
+            "entrypoint": "hello_world.py",
+            "files": [
+                {
+                    "name": "hello_world.py",
+                    "content": "print('Hello, World!')"
+                }
+            ]
+        }
+    ],
+    "context": {
+        "language": "PYTHON",
+        "memory_limit_mb": 1,
+        "time_limit_secs": 5,
+        "extra_options": {}
+    }
+}

--- a/examples/runtime_deps.json
+++ b/examples/runtime_deps.json
@@ -1,0 +1,30 @@
+{
+    "programs": [
+        {
+            "entrypoint": "main.py",
+            "files": [
+                {
+                    "name": "main.py",
+                    "content": "import polars as pl\n\npl.show_versions()"
+                }
+            ]
+        },
+        {
+            "entrypoint": "main.py",
+            "files": [
+                {
+                    "name": "main.py",
+                    "content": "import polars as pl\n\nprint(pl.DataFrame({'a': [1, 2, 3]}))"
+                }
+            ]
+        }
+    ],
+    "context": {
+        "language": "PYTHON",
+        "memory_limit_mb": 100,
+        "time_limit_secs": 5,
+        "extra_options": {
+            "requirements": "polars"
+        }
+    }
+}

--- a/examples/runtime_deps.json
+++ b/examples/runtime_deps.json
@@ -21,8 +21,8 @@
     ],
     "context": {
         "language": "PYTHON",
-        "memory_limit_mb": 100,
-        "time_limit_secs": 5,
+        "memory_limit_mb": 1000,
+        "time_limit_secs": 30,
         "extra_options": {
             "requirements": "polars"
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pika>=1.3.2",
     "python-dotenv>=1.0.1",
     "typer>=0.15.1",
+    "rich>=13.9.4",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "python-dotenv>=1.0.1",
     "typer>=0.15.1",
     "rich>=13.9.4",
+    "psutil>=6.1.1",
 ]
 
 [build-system]
@@ -22,6 +23,7 @@ build-backend = "hatchling.build"
 dev-dependencies = [
     "mypy>=1.11.2",
     "types-pika-ts>=1.3.0.20241203",
+    "types-psutil>=6.1.0.20241102",
 ]
 
 [tool.ruff]

--- a/unicon_runner/app.py
+++ b/unicon_runner/app.py
@@ -121,7 +121,7 @@ def test(
     root_wd_dir: RootWorkingDirectory,
     job_file: Annotated[Path, typer.Argument(exists=True, readable=True)],
     slurm: bool = False,
-    slurm_flags: str | None = None,
+    slurm_opt: list[str] | None = None,
 ) -> None:
     # Dynamically set the slurm flag
     import json
@@ -129,6 +129,7 @@ def test(
     job_json = json.loads(job_file.read_text())
     if "context" in job_json:
         job_json["context"]["slurm"] = slurm
+        job_json["context"]["slurm_options"] = slurm_opt or []
 
     job = Job.model_validate(job_json)
     executor = create_executor(exec_type, root_wd_dir)

--- a/unicon_runner/app.py
+++ b/unicon_runner/app.py
@@ -146,7 +146,7 @@ def test(
         prog_result = asyncio.run(_run_job(program))
 
         tbl = Table(title=f"Program Result #{i + 1}", highlight=True)
-        tbl.add_column("Status", style="magenta")
+        tbl.add_column("status", style="magenta")
         tbl.add_column("stdout")
         tbl.add_column("stderr", style="red")
         tbl.add_row(prog_result.status, prog_result.stdout, prog_result.stderr)

--- a/unicon_runner/app.py
+++ b/unicon_runner/app.py
@@ -1,6 +1,8 @@
 import asyncio
 from collections.abc import Awaitable, Callable
 from functools import partial
+from pathlib import Path
+from typing import Annotated
 
 import pika
 import pika.spec
@@ -71,10 +73,21 @@ def init_mq() -> tuple[BlockingChannel, BlockingChannel]:
 
 
 @app.command()
-def start(exec_type: ExecutorType):
+def start(
+    exec_type: ExecutorType,
+    root_wd_dir: Annotated[
+        Path,
+        typer.Argument(
+            exists=True,
+            writable=True,
+            readable=True,
+            help="Root path for executor's working directory",
+        ),
+    ],
+) -> None:
     in_ch, out_ch = init_mq()
 
-    executor = create_executor(exec_type)
+    executor = create_executor(exec_type, root_wd_dir)
 
     in_ch.basic_qos(prefetch_count=1)
     in_ch.basic_consume(

--- a/unicon_runner/app.py
+++ b/unicon_runner/app.py
@@ -140,7 +140,9 @@ def test(
     _console = Console()
 
     async def _run_job(program: Program) -> ProgramResult:
-        return await executor.run(program, job.context)
+        # Since this is a test, we don't want to clean up the working directory
+        # This is so that we can easily inspect the files written and replay the execution
+        return await executor.run(program, job.context, cleanup=False)
 
     for i, program in enumerate(job.programs):
         prog_result = asyncio.run(_run_job(program))

--- a/unicon_runner/constants.py
+++ b/unicon_runner/constants.py
@@ -12,8 +12,8 @@ def _get_env_var(name: str, default: str | None = None, required: bool = True):
     return value
 
 
-RABBITMQ_URL: str = _get_env_var("RABBITMQ_URL")
-CONTY_PATH: str = _get_env_var("CONTY_PATH")
+RABBITMQ_URL: str = _get_env_var("RABBITMQ_URL", required=False)
+CONTY_PATH: str = _get_env_var("CONTY_PATH", required=False)
 
 EXCHANGE_NAME = _get_env_var("EXCHANGE_NAME", "unicon")
 TASK_QUEUE_NAME = _get_env_var("WORK_QUEUE_NAME", "unicon.tasks")

--- a/unicon_runner/constants.py
+++ b/unicon_runner/constants.py
@@ -18,3 +18,5 @@ CONTY_PATH: str = _get_env_var("CONTY_PATH")
 EXCHANGE_NAME = _get_env_var("EXCHANGE_NAME", "unicon")
 TASK_QUEUE_NAME = _get_env_var("WORK_QUEUE_NAME", "unicon.tasks")
 RESULT_QUEUE_NAME = _get_env_var("RESULT_QUEUE_NAME", "unicon.results")
+
+DEFAULT_EXEC_PY_VERSION = "3.11.9"

--- a/unicon_runner/executor/__init__.py
+++ b/unicon_runner/executor/__init__.py
@@ -1,17 +1,19 @@
+from pathlib import Path
+
 from unicon_runner.executor.base import ExecutorType
 from unicon_runner.executor.podman import PodmanExecutor
 from unicon_runner.executor.sandbox import SandboxExecutor
 from unicon_runner.executor.unsafe import UnsafeExecutor
 
 
-def create_executor(executor_type: ExecutorType):
+def create_executor(executor_type: ExecutorType, root_wd_dir: Path):
     match executor_type:
         case ExecutorType.PODMAN:
-            return PodmanExecutor()
+            return PodmanExecutor(root_wd_dir)
         case ExecutorType.SANDBOX:
-            return SandboxExecutor()
+            return SandboxExecutor(root_wd_dir)
         case ExecutorType.UNSAFE:
-            return UnsafeExecutor()
+            return UnsafeExecutor(root_wd_dir)
 
 
 __all__ = ["PodmanExecutor", "SandboxExecutor", "UnsafeExecutor"]

--- a/unicon_runner/executor/base.py
+++ b/unicon_runner/executor/base.py
@@ -95,6 +95,7 @@ class Executor(ABC):
                 #   - A possible improvement is to introduce staging and execution directories
                 exec_dir = Path("/tmp") / id
                 prog_cmd, prog_env_vars = self._cmd(exec_dir)
+                logger.info(f"Program command: {prog_cmd}")
 
                 # Assemble the script that copies files from NFS to Slurm working directory
                 slurm_script = JINJA_ENV.get_template("slurm.sh.jinja").render(
@@ -115,7 +116,7 @@ class Executor(ABC):
                 cmd, env_vars = self._cmd(cwd)
 
             logger.info(f"Process command: {cmd}")
-            logger.info(f"Env vars: {env_vars}")
+            logger.info(f"Env variables: {env_vars}")
 
             result = await self._collect(
                 await asyncio.create_subprocess_shell(

--- a/unicon_runner/executor/base.py
+++ b/unicon_runner/executor/base.py
@@ -36,9 +36,8 @@ class ExecutorType(str, Enum):
 class Executor(ABC):
     on_slurm = False
 
-    @property
-    def root_dir(self) -> Path:
-        return Path("/tmp" if self.on_slurm else "temp")
+    def __init__(self, root_dir: Path):
+        self._root_dir = root_dir
 
     @abstractmethod
     def get_filesystem_mapping(
@@ -58,7 +57,7 @@ class Executor(ABC):
     async def run(self, program: Program, context: ComputeContext) -> ProgramResult:
         _tracking_fields = program.model_extra or {}
         id: str = str(uuid.uuid4())  # Unique identifier for the program
-        with ExecutorCwd(self.root_dir, id) as cwd:
+        with ExecutorCwd(self._root_dir, id) as cwd:
             for path, content, is_exec in self.get_filesystem_mapping(program, context):
                 file_path = cwd / path
                 file_path.parent.mkdir(parents=True, exist_ok=True)

--- a/unicon_runner/executor/base.py
+++ b/unicon_runner/executor/base.py
@@ -83,7 +83,7 @@ class Executor(ABC):
         if context.slurm and not is_mounted_on_nfs(self._root_dir):
             # NOTE: We assume that as long as the working directory is on **any** NFS,
             # all nodes in the cluster will have access to it
-            raise RuntimeError("Cannot run slurm jobs as the working directory is not on NFS")
+            raise RuntimeError("Cannot run slurm jobs as root working directory is not on NFS")
 
         _tracking_fields = program.model_extra or {}
         id: str = str(uuid.uuid4())  # Unique identifier for the program

--- a/unicon_runner/executor/base.py
+++ b/unicon_runner/executor/base.py
@@ -105,7 +105,7 @@ class Executor(ABC):
                 slurm_script_path.write_text(slurm_script)
                 slurm_script_path.chmod(slurm_script_path.stat().st_mode | stat.S_IEXEC)
 
-                cmd = ["srun", str(slurm_script_path)]
+                cmd = ["srun", *context.slurm_options, str(slurm_script_path)]
                 env_vars = {}
             else:
                 cmd, env_vars = self._cmd(cwd)

--- a/unicon_runner/executor/sandbox.py
+++ b/unicon_runner/executor/sandbox.py
@@ -1,18 +1,11 @@
 import asyncio
-import os
-import shlex
 from pathlib import Path
 
-from jinja2 import Environment, PackageLoader, Template, select_autoescape
+from jinja2 import Template
 
 from unicon_runner.constants import CONTY_PATH
-from unicon_runner.executor.base import ExecutorResult
+from unicon_runner.executor.base import JINJA_ENV, ExecutorResult
 from unicon_runner.executor.unsafe import UnsafeExecutor
-from unicon_runner.models import ComputeContext, Program
-
-JINJA_ENV = Environment(
-    loader=PackageLoader("unicon_runner.executor"), autoescape=select_autoescape()
-)
 
 
 class SandboxExecutor(UnsafeExecutor):
@@ -23,9 +16,9 @@ class SandboxExecutor(UnsafeExecutor):
 
     RUN_SCRIPT_TEMPLATE: Template = JINJA_ENV.get_template("run_sandbox.sh.jinja")
 
-    async def _execute(self, _: str, __: Program, cwd: Path, ___: ComputeContext) -> ExecutorResult:
-        if not Path(CONTY_PATH).exists():
-            raise RuntimeError(f"Conty binary not found at {CONTY_PATH}!")
+    def _cmd(self, cwd: Path) -> tuple[list[str], dict[str, str]]:
+        # if not Path(CONTY_PATH).exists():
+        #     raise RuntimeError(f"Conty binary not found at {CONTY_PATH}!")
 
         # NOTE: `uv` binary is assumed to be stored under `~/.cargo/bin/`
         # We are using `uv` as the environment manager and program runner
@@ -33,37 +26,29 @@ class SandboxExecutor(UnsafeExecutor):
         # NOTE: We need to bind the uv cache folder to access uv-managed python executables
         uv_cache_path = Path("~/.local/share/uv").expanduser()
 
-        async with self.lock:
-            exec_proc = await asyncio.create_subprocess_shell(
-                shlex.join(
-                    [
-                        CONTY_PATH,
-                        "--bind",
-                        str(cwd.absolute()),
-                        str(cwd),
-                        "--ro-bind",
-                        *([str(uv_path)] * 2),
-                        "--ro-bind",
-                        *([str(uv_cache_path)] * 2),
-                        str(cwd / self.ENTRYPOINT),
-                    ]
-                ),
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                env={
-                    **os.environ,
-                    # Conty specific environment variables
-                    "SANDBOX": "1",
-                    "SANDBOX_LEVEL": "1",
-                    "QUIET_MODE": "1",
-                    # NOTE: We need to unset VIRTUAL_ENV to prevent uv from using it
-                    "VIRTUAL_ENV": "",
-                },
-            )
+        return [
+            CONTY_PATH,
+            "--bind",
+            str(cwd.absolute()),
+            str(cwd),
+            "--ro-bind",
+            *([str(uv_path)] * 2),
+            "--ro-bind",
+            *([str(uv_cache_path)] * 2),
+            str(cwd / self.ENTRYPOINT),
+        ], {
+            # Conty specific environment variables
+            "SANDBOX": "1",
+            "SANDBOX_LEVEL": "1",
+            "QUIET_MODE": "1",
+            # NOTE: We need to unset VIRTUAL_ENV to prevent uv from using it
+            "VIRTUAL_ENV": "",
+        }
 
-            stdout, stderr = await exec_proc.communicate()
+    async def _collect(self, proc: asyncio.subprocess.Process) -> ExecutorResult:
+        stdout, stderr = await proc.communicate()
 
-        exit_code_file = cwd / "exit_code"
+        exit_code_file = self._root_dir / "exit_code"
         if not exit_code_file.exists():
             exit_code = 1
         else:

--- a/unicon_runner/executor/sandbox.py
+++ b/unicon_runner/executor/sandbox.py
@@ -41,8 +41,8 @@ class SandboxExecutor(UnsafeExecutor):
             "SANDBOX": "1",
             "SANDBOX_LEVEL": "1",
             "QUIET_MODE": "1",
-            # NOTE: We need to unset VIRTUAL_ENV to prevent uv from using it
-            "VIRTUAL_ENV": "",
+            # NOTE: We need to unset VIRTUAL_ENV to prevent uv from using the wrong base python interpreter
+            "VIRTUAL_ENV": "''",
         }
 
     async def _collect(self, proc: asyncio.subprocess.Process) -> ExecutorResult:

--- a/unicon_runner/executor/templates/pyproject.toml.jinja
+++ b/unicon_runner/executor/templates/pyproject.toml.jinja
@@ -1,7 +1,6 @@
 [project]
 name = "src"
 version = "0.1.0"
-requires-python = ">=3.11"
 dependencies = []
 
 [build-system]

--- a/unicon_runner/executor/templates/run_unsafe.sh.jinja
+++ b/unicon_runner/executor/templates/run_unsafe.sh.jinja
@@ -5,7 +5,7 @@ cd "$(dirname "$0")"
 
 # Install required Python interpreter and dependencies
 uv -q venv --python {{ python_version }}
-uv -q add -r requirements.txt
+uv -q --no-cache add -r requirements.txt
 
 # NOTE: Memory limit is set in kilobytes
 # Reference: https://ss64.com/bash/ulimit.html

--- a/unicon_runner/executor/templates/slurm.sh.jinja
+++ b/unicon_runner/executor/templates/slurm.sh.jinja
@@ -6,5 +6,8 @@ mkdir -p {{ exec_dir }}
 # Copy all files from the NFS staging directory to the execution directory
 cp -r {{ staging_dir }}/* {{ exec_dir }}
 
+# Environment variables for program execution
+{{ exec_export_env_vars }}
+
 # Run the job script
 {{ run_script }}

--- a/unicon_runner/executor/templates/slurm.sh.jinja
+++ b/unicon_runner/executor/templates/slurm.sh.jinja
@@ -4,7 +4,7 @@
 mkdir -p {{ exec_dir }}
 
 # Copy all files from the NFS staging directory to the execution directory
-cp -r {{ staging_dir }} {{ exec_dir }}
+cp -r {{ staging_dir }}/* {{ exec_dir }}
 
 # Run the job script
 {{ run_script }}

--- a/unicon_runner/executor/templates/slurm.sh.jinja
+++ b/unicon_runner/executor/templates/slurm.sh.jinja
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Create the execution directory
+mkdir -p {{ exec_dir }}
+
+# Copy all files from the NFS staging directory to the execution directory
+cp -r {{ staging_dir }} {{ exec_dir }}
+
+# Run the job script
+{{ run_script }}

--- a/unicon_runner/executor/unsafe.py
+++ b/unicon_runner/executor/unsafe.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from jinja2 import Template
 
+from unicon_runner.constants import DEFAULT_EXEC_PY_VERSION
 from unicon_runner.executor.base import JINJA_ENV, Executor, FileSystemMapping
 from unicon_runner.models import ComputeContext, Program
 
@@ -24,8 +25,12 @@ class UnsafeExecutor(Executor):
         mem_limit_kb: int = context.memory_limit_mb * 1024
         time_limit_secs: int = context.time_limit_secs * 1000
 
-        python_version: str = "3.11.9"
-        if context.extra_options:
+        python_version: str = DEFAULT_EXEC_PY_VERSION
+        if context.slurm:
+            # NOTE: We need to use the system python interpreter for slurm jobs
+            # This is because of filesystem restrictions in the slurm environment (more details in the docs)
+            python_version = "/usr/bin/python"
+        elif context.extra_options:
             python_version = context.extra_options.get("version", python_version)
 
         run_script = self.RUN_SCRIPT_TEMPLATE.render(

--- a/unicon_runner/executor/unsafe.py
+++ b/unicon_runner/executor/unsafe.py
@@ -44,4 +44,4 @@ class UnsafeExecutor(Executor):
         ]
 
     def _cmd(self, cwd: Path) -> tuple[list[str], dict[str, str]]:
-        return [str(cwd / self.ENTRYPOINT)], {"VIRTUAL_ENV": ""}
+        return [str(cwd / self.ENTRYPOINT)], {"VIRTUAL_ENV": "''"}

--- a/unicon_runner/executor/unsafe.py
+++ b/unicon_runner/executor/unsafe.py
@@ -49,4 +49,5 @@ class UnsafeExecutor(Executor):
         ]
 
     def _cmd(self, cwd: Path) -> tuple[list[str], dict[str, str]]:
+        # NOTE: We need to unset VIRTUAL_ENV to prevent uv from using the wrong base python interpreter
         return [str(cwd / self.ENTRYPOINT)], {"VIRTUAL_ENV": "''"}

--- a/unicon_runner/models.py
+++ b/unicon_runner/models.py
@@ -26,6 +26,8 @@ class ComputeContext(BaseModel):
     time_limit_secs: int
     memory_limit_mb: int
 
+    slurm: bool
+
     extra_options: dict[str, str] | None
 
 

--- a/unicon_runner/models.py
+++ b/unicon_runner/models.py
@@ -26,7 +26,8 @@ class ComputeContext(BaseModel):
     time_limit_secs: int
     memory_limit_mb: int
 
-    slurm: bool
+    slurm: bool = False
+    slurm_options: list[str] = []
 
     extra_options: dict[str, str] | None
 

--- a/uv.lock
+++ b/uv.lock
@@ -154,55 +154,55 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.10.3"
+version = "2.10.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
     { name = "pydantic-core" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/0f/27908242621b14e649a84e62b133de45f84c255eecb350ab02979844a788/pydantic-2.10.3.tar.gz", hash = "sha256:cb5ac360ce894ceacd69c403187900a02c4b20b693a9dd1d643e1effab9eadf9", size = 786486 }
+sdist = { url = "https://files.pythonhosted.org/packages/70/7e/fb60e6fee04d0ef8f15e4e01ff187a196fa976eb0f0ab524af4599e5754c/pydantic-2.10.4.tar.gz", hash = "sha256:82f12e9723da6de4fe2ba888b5971157b3be7ad914267dea8f05f82b28254f06", size = 762094 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/51/72c18c55cf2f46ff4f91ebcc8f75aa30f7305f3d726be3f4ebffb4ae972b/pydantic-2.10.3-py3-none-any.whl", hash = "sha256:be04d85bbc7b65651c5f8e6b9976ed9c6f41782a55524cef079a34a0bb82144d", size = 456997 },
+    { url = "https://files.pythonhosted.org/packages/f3/26/3e1bbe954fde7ee22a6e7d31582c642aad9e84ffe4b5fb61e63b87cd326f/pydantic-2.10.4-py3-none-any.whl", hash = "sha256:597e135ea68be3a37552fb524bc7d0d66dcf93d395acd93a00682f1efcb8ee3d", size = 431765 },
 ]
 
 [[package]]
 name = "pydantic-core"
-version = "2.27.1"
+version = "2.27.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/9f/7de1f19b6aea45aeb441838782d68352e71bfa98ee6fa048d5041991b33e/pydantic_core-2.27.1.tar.gz", hash = "sha256:62a763352879b84aa31058fc931884055fd75089cccbd9d58bb6afd01141b235", size = 412785 }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/01/f3e5ac5e7c25833db5eb555f7b7ab24cd6f8c322d3a3ad2d67a952dc0abc/pydantic_core-2.27.2.tar.gz", hash = "sha256:eb026e5a4c1fee05726072337ff51d1efb6f59090b7da90d30ea58625b1ffb39", size = 413443 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/51/2e9b3788feb2aebff2aa9dfbf060ec739b38c05c46847601134cc1fed2ea/pydantic_core-2.27.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:9cbd94fc661d2bab2bc702cddd2d3370bbdcc4cd0f8f57488a81bcce90c7a54f", size = 1895239 },
-    { url = "https://files.pythonhosted.org/packages/7b/9e/f8063952e4a7d0127f5d1181addef9377505dcce3be224263b25c4f0bfd9/pydantic_core-2.27.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5f8c4718cd44ec1580e180cb739713ecda2bdee1341084c1467802a417fe0f02", size = 1805070 },
-    { url = "https://files.pythonhosted.org/packages/2c/9d/e1d6c4561d262b52e41b17a7ef8301e2ba80b61e32e94520271029feb5d8/pydantic_core-2.27.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:15aae984e46de8d376df515f00450d1522077254ef6b7ce189b38ecee7c9677c", size = 1828096 },
-    { url = "https://files.pythonhosted.org/packages/be/65/80ff46de4266560baa4332ae3181fffc4488ea7d37282da1a62d10ab89a4/pydantic_core-2.27.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1ba5e3963344ff25fc8c40da90f44b0afca8cfd89d12964feb79ac1411a260ac", size = 1857708 },
-    { url = "https://files.pythonhosted.org/packages/d5/ca/3370074ad758b04d9562b12ecdb088597f4d9d13893a48a583fb47682cdf/pydantic_core-2.27.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:992cea5f4f3b29d6b4f7f1726ed8ee46c8331c6b4eed6db5b40134c6fe1768bb", size = 2037751 },
-    { url = "https://files.pythonhosted.org/packages/b1/e2/4ab72d93367194317b99d051947c071aef6e3eb95f7553eaa4208ecf9ba4/pydantic_core-2.27.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0325336f348dbee6550d129b1627cb8f5351a9dc91aad141ffb96d4937bd9529", size = 2733863 },
-    { url = "https://files.pythonhosted.org/packages/8a/c6/8ae0831bf77f356bb73127ce5a95fe115b10f820ea480abbd72d3cc7ccf3/pydantic_core-2.27.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7597c07fbd11515f654d6ece3d0e4e5093edc30a436c63142d9a4b8e22f19c35", size = 2161161 },
-    { url = "https://files.pythonhosted.org/packages/f1/f4/b2fe73241da2429400fc27ddeaa43e35562f96cf5b67499b2de52b528cad/pydantic_core-2.27.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3bbd5d8cc692616d5ef6fbbbd50dbec142c7e6ad9beb66b78a96e9c16729b089", size = 1993294 },
-    { url = "https://files.pythonhosted.org/packages/77/29/4bb008823a7f4cc05828198153f9753b3bd4c104d93b8e0b1bfe4e187540/pydantic_core-2.27.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:dc61505e73298a84a2f317255fcc72b710b72980f3a1f670447a21efc88f8381", size = 2001468 },
-    { url = "https://files.pythonhosted.org/packages/f2/a9/0eaceeba41b9fad851a4107e0cf999a34ae8f0d0d1f829e2574f3d8897b0/pydantic_core-2.27.1-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:e1f735dc43da318cad19b4173dd1ffce1d84aafd6c9b782b3abc04a0d5a6f5bb", size = 2091413 },
-    { url = "https://files.pythonhosted.org/packages/d8/36/eb8697729725bc610fd73940f0d860d791dc2ad557faaefcbb3edbd2b349/pydantic_core-2.27.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:f4e5658dbffe8843a0f12366a4c2d1c316dbe09bb4dfbdc9d2d9cd6031de8aae", size = 2154735 },
-    { url = "https://files.pythonhosted.org/packages/52/e5/4f0fbd5c5995cc70d3afed1b5c754055bb67908f55b5cb8000f7112749bf/pydantic_core-2.27.1-cp312-none-win32.whl", hash = "sha256:672ebbe820bb37988c4d136eca2652ee114992d5d41c7e4858cdd90ea94ffe5c", size = 1833633 },
-    { url = "https://files.pythonhosted.org/packages/ee/f2/c61486eee27cae5ac781305658779b4a6b45f9cc9d02c90cb21b940e82cc/pydantic_core-2.27.1-cp312-none-win_amd64.whl", hash = "sha256:66ff044fd0bb1768688aecbe28b6190f6e799349221fb0de0e6f4048eca14c16", size = 1986973 },
-    { url = "https://files.pythonhosted.org/packages/df/a6/e3f12ff25f250b02f7c51be89a294689d175ac76e1096c32bf278f29ca1e/pydantic_core-2.27.1-cp312-none-win_arm64.whl", hash = "sha256:9a3b0793b1bbfd4146304e23d90045f2a9b5fd5823aa682665fbdaf2a6c28f3e", size = 1883215 },
-    { url = "https://files.pythonhosted.org/packages/0f/d6/91cb99a3c59d7b072bded9959fbeab0a9613d5a4935773c0801f1764c156/pydantic_core-2.27.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f216dbce0e60e4d03e0c4353c7023b202d95cbaeff12e5fd2e82ea0a66905073", size = 1895033 },
-    { url = "https://files.pythonhosted.org/packages/07/42/d35033f81a28b27dedcade9e967e8a40981a765795c9ebae2045bcef05d3/pydantic_core-2.27.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a2e02889071850bbfd36b56fd6bc98945e23670773bc7a76657e90e6b6603c08", size = 1807542 },
-    { url = "https://files.pythonhosted.org/packages/41/c2/491b59e222ec7e72236e512108ecad532c7f4391a14e971c963f624f7569/pydantic_core-2.27.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42b0e23f119b2b456d07ca91b307ae167cc3f6c846a7b169fca5326e32fdc6cf", size = 1827854 },
-    { url = "https://files.pythonhosted.org/packages/e3/f3/363652651779113189cefdbbb619b7b07b7a67ebb6840325117cc8cc3460/pydantic_core-2.27.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:764be71193f87d460a03f1f7385a82e226639732214b402f9aa61f0d025f0737", size = 1857389 },
-    { url = "https://files.pythonhosted.org/packages/5f/97/be804aed6b479af5a945daec7538d8bf358d668bdadde4c7888a2506bdfb/pydantic_core-2.27.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c00666a3bd2f84920a4e94434f5974d7bbc57e461318d6bb34ce9cdbbc1f6b2", size = 2037934 },
-    { url = "https://files.pythonhosted.org/packages/42/01/295f0bd4abf58902917e342ddfe5f76cf66ffabfc57c2e23c7681a1a1197/pydantic_core-2.27.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3ccaa88b24eebc0f849ce0a4d09e8a408ec5a94afff395eb69baf868f5183107", size = 2735176 },
-    { url = "https://files.pythonhosted.org/packages/9d/a0/cd8e9c940ead89cc37812a1a9f310fef59ba2f0b22b4e417d84ab09fa970/pydantic_core-2.27.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c65af9088ac534313e1963443d0ec360bb2b9cba6c2909478d22c2e363d98a51", size = 2160720 },
-    { url = "https://files.pythonhosted.org/packages/73/ae/9d0980e286627e0aeca4c352a60bd760331622c12d576e5ea4441ac7e15e/pydantic_core-2.27.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:206b5cf6f0c513baffaeae7bd817717140770c74528f3e4c3e1cec7871ddd61a", size = 1992972 },
-    { url = "https://files.pythonhosted.org/packages/bf/ba/ae4480bc0292d54b85cfb954e9d6bd226982949f8316338677d56541b85f/pydantic_core-2.27.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:062f60e512fc7fff8b8a9d680ff0ddaaef0193dba9fa83e679c0c5f5fbd018bc", size = 2001477 },
-    { url = "https://files.pythonhosted.org/packages/55/b7/e26adf48c2f943092ce54ae14c3c08d0d221ad34ce80b18a50de8ed2cba8/pydantic_core-2.27.1-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:a0697803ed7d4af5e4c1adf1670af078f8fcab7a86350e969f454daf598c4960", size = 2091186 },
-    { url = "https://files.pythonhosted.org/packages/ba/cc/8491fff5b608b3862eb36e7d29d36a1af1c945463ca4c5040bf46cc73f40/pydantic_core-2.27.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:58ca98a950171f3151c603aeea9303ef6c235f692fe555e883591103da709b23", size = 2154429 },
-    { url = "https://files.pythonhosted.org/packages/78/d8/c080592d80edd3441ab7f88f865f51dae94a157fc64283c680e9f32cf6da/pydantic_core-2.27.1-cp313-none-win32.whl", hash = "sha256:8065914ff79f7eab1599bd80406681f0ad08f8e47c880f17b416c9f8f7a26d05", size = 1833713 },
-    { url = "https://files.pythonhosted.org/packages/83/84/5ab82a9ee2538ac95a66e51f6838d6aba6e0a03a42aa185ad2fe404a4e8f/pydantic_core-2.27.1-cp313-none-win_amd64.whl", hash = "sha256:ba630d5e3db74c79300d9a5bdaaf6200172b107f263c98a0539eeecb857b2337", size = 1987897 },
-    { url = "https://files.pythonhosted.org/packages/df/c3/b15fb833926d91d982fde29c0624c9f225da743c7af801dace0d4e187e71/pydantic_core-2.27.1-cp313-none-win_arm64.whl", hash = "sha256:45cf8588c066860b623cd11c4ba687f8d7175d5f7ef65f7129df8a394c502de5", size = 1882983 },
+    { url = "https://files.pythonhosted.org/packages/d6/74/51c8a5482ca447871c93e142d9d4a92ead74de6c8dc5e66733e22c9bba89/pydantic_core-2.27.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:9e0c8cfefa0ef83b4da9588448b6d8d2a2bf1a53c3f1ae5fca39eb3061e2f0b0", size = 1893127 },
+    { url = "https://files.pythonhosted.org/packages/d3/f3/c97e80721735868313c58b89d2de85fa80fe8dfeeed84dc51598b92a135e/pydantic_core-2.27.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:83097677b8e3bd7eaa6775720ec8e0405f1575015a463285a92bfdfe254529ef", size = 1811340 },
+    { url = "https://files.pythonhosted.org/packages/9e/91/840ec1375e686dbae1bd80a9e46c26a1e0083e1186abc610efa3d9a36180/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:172fce187655fece0c90d90a678424b013f8fbb0ca8b036ac266749c09438cb7", size = 1822900 },
+    { url = "https://files.pythonhosted.org/packages/f6/31/4240bc96025035500c18adc149aa6ffdf1a0062a4b525c932065ceb4d868/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:519f29f5213271eeeeb3093f662ba2fd512b91c5f188f3bb7b27bc5973816934", size = 1869177 },
+    { url = "https://files.pythonhosted.org/packages/fa/20/02fbaadb7808be578317015c462655c317a77a7c8f0ef274bc016a784c54/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:05e3a55d124407fffba0dd6b0c0cd056d10e983ceb4e5dbd10dda135c31071d6", size = 2038046 },
+    { url = "https://files.pythonhosted.org/packages/06/86/7f306b904e6c9eccf0668248b3f272090e49c275bc488a7b88b0823444a4/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9c3ed807c7b91de05e63930188f19e921d1fe90de6b4f5cd43ee7fcc3525cb8c", size = 2685386 },
+    { url = "https://files.pythonhosted.org/packages/8d/f0/49129b27c43396581a635d8710dae54a791b17dfc50c70164866bbf865e3/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6fb4aadc0b9a0c063206846d603b92030eb6f03069151a625667f982887153e2", size = 1997060 },
+    { url = "https://files.pythonhosted.org/packages/0d/0f/943b4af7cd416c477fd40b187036c4f89b416a33d3cc0ab7b82708a667aa/pydantic_core-2.27.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28ccb213807e037460326424ceb8b5245acb88f32f3d2777427476e1b32c48c4", size = 2004870 },
+    { url = "https://files.pythonhosted.org/packages/35/40/aea70b5b1a63911c53a4c8117c0a828d6790483f858041f47bab0b779f44/pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:de3cd1899e2c279b140adde9357c4495ed9d47131b4a4eaff9052f23398076b3", size = 1999822 },
+    { url = "https://files.pythonhosted.org/packages/f2/b3/807b94fd337d58effc5498fd1a7a4d9d59af4133e83e32ae39a96fddec9d/pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:220f892729375e2d736b97d0e51466252ad84c51857d4d15f5e9692f9ef12be4", size = 2130364 },
+    { url = "https://files.pythonhosted.org/packages/fc/df/791c827cd4ee6efd59248dca9369fb35e80a9484462c33c6649a8d02b565/pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a0fcd29cd6b4e74fe8ddd2c90330fd8edf2e30cb52acda47f06dd615ae72da57", size = 2158303 },
+    { url = "https://files.pythonhosted.org/packages/9b/67/4e197c300976af185b7cef4c02203e175fb127e414125916bf1128b639a9/pydantic_core-2.27.2-cp312-cp312-win32.whl", hash = "sha256:1e2cb691ed9834cd6a8be61228471d0a503731abfb42f82458ff27be7b2186fc", size = 1834064 },
+    { url = "https://files.pythonhosted.org/packages/1f/ea/cd7209a889163b8dcca139fe32b9687dd05249161a3edda62860430457a5/pydantic_core-2.27.2-cp312-cp312-win_amd64.whl", hash = "sha256:cc3f1a99a4f4f9dd1de4fe0312c114e740b5ddead65bb4102884b384c15d8bc9", size = 1989046 },
+    { url = "https://files.pythonhosted.org/packages/bc/49/c54baab2f4658c26ac633d798dab66b4c3a9bbf47cff5284e9c182f4137a/pydantic_core-2.27.2-cp312-cp312-win_arm64.whl", hash = "sha256:3911ac9284cd8a1792d3cb26a2da18f3ca26c6908cc434a18f730dc0db7bfa3b", size = 1885092 },
+    { url = "https://files.pythonhosted.org/packages/41/b1/9bc383f48f8002f99104e3acff6cba1231b29ef76cfa45d1506a5cad1f84/pydantic_core-2.27.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:7d14bd329640e63852364c306f4d23eb744e0f8193148d4044dd3dacdaacbd8b", size = 1892709 },
+    { url = "https://files.pythonhosted.org/packages/10/6c/e62b8657b834f3eb2961b49ec8e301eb99946245e70bf42c8817350cbefc/pydantic_core-2.27.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:82f91663004eb8ed30ff478d77c4d1179b3563df6cdb15c0817cd1cdaf34d154", size = 1811273 },
+    { url = "https://files.pythonhosted.org/packages/ba/15/52cfe49c8c986e081b863b102d6b859d9defc63446b642ccbbb3742bf371/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:71b24c7d61131bb83df10cc7e687433609963a944ccf45190cfc21e0887b08c9", size = 1823027 },
+    { url = "https://files.pythonhosted.org/packages/b1/1c/b6f402cfc18ec0024120602bdbcebc7bdd5b856528c013bd4d13865ca473/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fa8e459d4954f608fa26116118bb67f56b93b209c39b008277ace29937453dc9", size = 1868888 },
+    { url = "https://files.pythonhosted.org/packages/bd/7b/8cb75b66ac37bc2975a3b7de99f3c6f355fcc4d89820b61dffa8f1e81677/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ce8918cbebc8da707ba805b7fd0b382816858728ae7fe19a942080c24e5b7cd1", size = 2037738 },
+    { url = "https://files.pythonhosted.org/packages/c8/f1/786d8fe78970a06f61df22cba58e365ce304bf9b9f46cc71c8c424e0c334/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3f5c2a021bbc5d976107bb302e0131351c2ba54343f8a496dc8783d3d3a6a", size = 2685138 },
+    { url = "https://files.pythonhosted.org/packages/a6/74/d12b2cd841d8724dc8ffb13fc5cef86566a53ed358103150209ecd5d1999/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd8086fa684c4775c27f03f062cbb9eaa6e17f064307e86b21b9e0abc9c0f02e", size = 1997025 },
+    { url = "https://files.pythonhosted.org/packages/a0/6e/940bcd631bc4d9a06c9539b51f070b66e8f370ed0933f392db6ff350d873/pydantic_core-2.27.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8d9b3388db186ba0c099a6d20f0604a44eabdeef1777ddd94786cdae158729e4", size = 2004633 },
+    { url = "https://files.pythonhosted.org/packages/50/cc/a46b34f1708d82498c227d5d80ce615b2dd502ddcfd8376fc14a36655af1/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7a66efda2387de898c8f38c0cf7f14fca0b51a8ef0b24bfea5849f1b3c95af27", size = 1999404 },
+    { url = "https://files.pythonhosted.org/packages/ca/2d/c365cfa930ed23bc58c41463bae347d1005537dc8db79e998af8ba28d35e/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:18a101c168e4e092ab40dbc2503bdc0f62010e95d292b27827871dc85450d7ee", size = 2130130 },
+    { url = "https://files.pythonhosted.org/packages/f4/d7/eb64d015c350b7cdb371145b54d96c919d4db516817f31cd1c650cae3b21/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ba5dd002f88b78a4215ed2f8ddbdf85e8513382820ba15ad5ad8955ce0ca19a1", size = 2157946 },
+    { url = "https://files.pythonhosted.org/packages/a4/99/bddde3ddde76c03b65dfd5a66ab436c4e58ffc42927d4ff1198ffbf96f5f/pydantic_core-2.27.2-cp313-cp313-win32.whl", hash = "sha256:1ebaf1d0481914d004a573394f4be3a7616334be70261007e47c2a6fe7e50130", size = 1834387 },
+    { url = "https://files.pythonhosted.org/packages/71/47/82b5e846e01b26ac6f1893d3c5f9f3a2eb6ba79be26eef0b759b4fe72946/pydantic_core-2.27.2-cp313-cp313-win_amd64.whl", hash = "sha256:953101387ecf2f5652883208769a79e48db18c6df442568a0b5ccd8c2723abee", size = 1990453 },
+    { url = "https://files.pythonhosted.org/packages/51/b2/b2b50d5ecf21acf870190ae5d093602d95f66c9c31f9d5de6062eb329ad1/pydantic_core-2.27.2-cp313-cp313-win_arm64.whl", hash = "sha256:ac4dbfd1691affb8f48c2c13241a2e3b60ff23247cbcf981759c768b6633cf8b", size = 1885186 },
 ]
 
 [[package]]
@@ -288,6 +288,7 @@ dependencies = [
     { name = "pika" },
     { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "rich" },
     { name = "typer" },
 ]
 
@@ -304,6 +305,7 @@ requires-dist = [
     { name = "pika", specifier = ">=1.3.2" },
     { name = "pydantic", specifier = ">=2.9.2" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
+    { name = "rich", specifier = ">=13.9.4" },
     { name = "typer", specifier = ">=0.15.1" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -153,6 +153,21 @@ wheels = [
 ]
 
 [[package]]
+name = "psutil"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/5a/07871137bb752428aa4b659f910b399ba6f291156bdea939be3e96cae7cb/psutil-6.1.1.tar.gz", hash = "sha256:cf8496728c18f2d0b45198f06895be52f36611711746b7f30c464b422b50e2f5", size = 508502 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/99/ca79d302be46f7bdd8321089762dd4476ee725fce16fc2b2e1dbba8cac17/psutil-6.1.1-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:fc0ed7fe2231a444fc219b9c42d0376e0a9a1a72f16c5cfa0f68d19f1a0663e8", size = 247511 },
+    { url = "https://files.pythonhosted.org/packages/0b/6b/73dbde0dd38f3782905d4587049b9be64d76671042fdcaf60e2430c6796d/psutil-6.1.1-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:0bdd4eab935276290ad3cb718e9809412895ca6b5b334f5a9111ee6d9aff9377", size = 248985 },
+    { url = "https://files.pythonhosted.org/packages/17/38/c319d31a1d3f88c5b79c68b3116c129e5133f1822157dd6da34043e32ed6/psutil-6.1.1-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b6e06c20c05fe95a3d7302d74e7097756d4ba1247975ad6905441ae1b5b66003", size = 284488 },
+    { url = "https://files.pythonhosted.org/packages/9c/39/0f88a830a1c8a3aba27fededc642da37613c57cbff143412e3536f89784f/psutil-6.1.1-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:97f7cb9921fbec4904f522d972f0c0e1f4fabbdd4e0287813b21215074a0f160", size = 287477 },
+    { url = "https://files.pythonhosted.org/packages/47/da/99f4345d4ddf2845cb5b5bd0d93d554e84542d116934fde07a0c50bd4e9f/psutil-6.1.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:33431e84fee02bc84ea36d9e2c4a6d395d479c9dd9bba2376c1f6ee8f3a4e0b3", size = 289017 },
+    { url = "https://files.pythonhosted.org/packages/38/53/bd755c2896f4461fd4f36fa6a6dcb66a88a9e4b9fd4e5b66a77cf9d4a584/psutil-6.1.1-cp37-abi3-win32.whl", hash = "sha256:eaa912e0b11848c4d9279a93d7e2783df352b082f40111e078388701fd479e53", size = 250602 },
+    { url = "https://files.pythonhosted.org/packages/7b/d7/7831438e6c3ebbfa6e01a927127a6cb42ad3ab844247f3c5b96bea25d73d/psutil-6.1.1-cp37-abi3-win_amd64.whl", hash = "sha256:f35cfccb065fff93529d2afb4a2e89e363fe63ca1e4a5da22b603a85833c2649", size = 254444 },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.10.4"
 source = { registry = "https://pypi.org/simple" }
@@ -270,6 +285,15 @@ wheels = [
 ]
 
 [[package]]
+name = "types-psutil"
+version = "6.1.0.20241102"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/03/015b10b717747922457b54ecd3e2ac3b174d87667b74108f66ccf1c75636/types-psutil-6.1.0.20241102.tar.gz", hash = "sha256:8cbe086b9c29f5c0aa55c4422498c07a8e506f096205761dba088905198551dc", size = 15447 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/93/b84f9e33febb4745206882c24434d67dc04115ac04e61132c337c797a65f/types_psutil-6.1.0.20241102-py3-none-any.whl", hash = "sha256:61f836f8ba48f28f0d290d3bcd902f9130ce5057a1676e6ecbefb6141e2743f4", size = 18653 },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.12.2"
 source = { registry = "https://pypi.org/simple" }
@@ -286,6 +310,7 @@ dependencies = [
     { name = "jinja2" },
     { name = "pathvalidate" },
     { name = "pika" },
+    { name = "psutil" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "rich" },
@@ -296,6 +321,7 @@ dependencies = [
 dev = [
     { name = "mypy" },
     { name = "types-pika-ts" },
+    { name = "types-psutil" },
 ]
 
 [package.metadata]
@@ -303,6 +329,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.4" },
     { name = "pathvalidate", specifier = ">=3.2.1" },
     { name = "pika", specifier = ">=1.3.2" },
+    { name = "psutil", specifier = ">=6.1.1" },
     { name = "pydantic", specifier = ">=2.9.2" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "rich", specifier = ">=13.9.4" },
@@ -313,4 +340,5 @@ requires-dist = [
 dev = [
     { name = "mypy", specifier = ">=1.11.2" },
     { name = "types-pika-ts", specifier = ">=1.3.0.20241203" },
+    { name = "types-psutil", specifier = ">=6.1.0.20241102" },
 ]


### PR DESCRIPTION
Accompanying PR: https://github.com/uniconhq/unicon-backend/pull/52

## Description

This PR adds functionality to the runner by allowing programs to be executed via `slurm` workload manager. Two additional fields are added to `Job::context` (`ComputeContext`):

- `slurm :: bool`: A toggle field to determine if the job (and the programs within) should be scheduled by `slurm`
- `slurm_options :: list[str]`: Extra options to be added to `srun` (also possibly `sbatch` in the future)
    - e.g. `["--gpus=<num-gpus>", "-p", "<partition-name>]`
    - There's **no** validation for these options, hence if an invalid option is specified, the program fails.
    - _This allows users to specify all possible configurations allowed by `srun`, but may not be ideal as it could be prone to errors. The middle ground is probably exposing a set of default options to the `ComputeContext` schema. However since we are still not sure what options are useful, this setup feels like a good start to allow program execution via `slurm`._

Our executors (`unsafe`, `sandbox`, `podman`) assemble/create processes* to be run and `slurm` is treated as a process scheduler. **As such, all programs, regardless of how it is chosen to be executed, can be scheduled via `slurm`**. However, because of constraints on the primary deployment site, `xlog` (soc compute cluster), `PodmanExecutor` will not work (for now).

> *The command to be run, the environment variables to be run with, files needed and resource limits (time & virtual memory)

**I have also added some important details of the `xlog` environment in the https://github.com/uniconhq/unicon-runner/wiki/xlog-%E2%80%90-SoC-Compute-Cluster wiki page. It outlines some important constraints that we need to be aware of and deal with.**

## Usage

To start a long running consumer that waits for jobs from the task queue:

```sh
uv run unicon_runner/app.py start <executor-type> <root-working-directory>
```
- `<root-working-directory>`: The root directory that will contain all executor working directories
    - Each program will be assigned working directory with path `<root-working-directory>/<program-id>`
        - `<program-id>` is a `UUID` generated upon execution - it is not used by `unicon-backend` for any tracking or reconciliation

To test execution of jobs:

```sh
uv run unicon_runner/app.py test <executor-type> <root-working-directory> \
    <job-file> \ # JSON file containing a `Job` object without any `slurm` params
    [--slurm] \ # Whether to run it via `slurm`
    [--slurm-opt] \ # `slurm` options
```

- Some samples of jobs can be found under `/examples` folder

**TODOs**

- [x] CLI command to test executions + sample programs and compute contexts
- [x] Add logging
- [x] Add parameter to support choosing specify `slurm` clusters (via a param that accepts arbitrary options/flags)
- [x] Update `README`
- [x] Align python version in `pyproject.toml` with `venv`
- [x] Error if root working directory is not mounted on NFS when if `context::slurm == true`
- [x] Log program cmd and env vars for slurm executions